### PR TITLE
Fixing reorder sequence when defining several variables

### DIFF
--- a/R/texreg.R
+++ b/R/texreg.R
@@ -289,11 +289,11 @@ texreg <- function(l, file = NULL, single.row = FALSE,
       digits, returnobject = "decimal.matrix")
   
   m <- customnames(m, custom.coef.names)  #rename coefficients
-  m <- replaceSymbols(m)
   m <- rearrangeMatrix(m)  #resort matrix and conflate duplicate entries
   m <- as.data.frame(m)
   m <- omitcoef(m, omit.coef)  #remove coefficient rows matching regex
-  
+  m <- replaceSymbols(m)
+   
   modnames <- modelnames(l, models, custom.model.names)  # model names
   
   # reorder GOF and coef matrix


### PR DESCRIPTION
Fixing "Error in reorder(m, reorder.coef) : Error when reordering matrix" when using several variables.