### PR TITLE
support for several Zelig models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Author: Philip Leifeld
 Maintainer: Philip Leifeld <philip.leifeld@glasgow.ac.uk>
 Description: Converts coefficients, standard errors, significance stars, and goodness-of-fit statistics of statistical models into LaTeX tables or HTML tables/MS Word documents or to nicely formatted screen output for the R console for easy model comparison. A list of several models can be combined in a single table. The output is highly customizable. New model types can be easily implemented.
 URL: http://github.com/leifeld/texreg/
-Suggests: nlme, survival, network, ergm, lme4 (>= 1.0), btergm
+Suggests: nlme, survival, network, ergm, lme4 (>= 1.0), btergm, Zelig (>= 5.0-16)
 Depends: R (>= 2.15.0)
 Imports: methods, grDevices, graphics, stats
 Enhances: AER, betareg, brglm, censReg, dynlm, eha, erer, fGarch, gamlss, gee, geepack, gmm, h2o, latentnet, lmtest, lqmm, MASS, mfx, mgcv, mlogit, mnlogit, MuMIn, nnet, ordinal, plm, pscl, quantreg, relevent, rms, robustbase, RSiena, sampleSelection, simex, sna, spdep, survey, systemfit, tergm, xergm, Zelig

--- a/R/extract.R
+++ b/R/extract.R
@@ -4723,7 +4723,7 @@ extract.Zelig <- function(model, ...) {
       stop("texreg relies on Zelig's from_zelig_model function to extract model information. Install Zelig >= 5.0-16 to see if texreg can format your model.")
     }
     mod_original <- try(Zelig::from_zelig_model(model), silent = TRUE)
-    if (class(mod_original) == 'try-error') {
+    if (class(mod_original)[1] == 'try-error') {
       stop("texreg relies on Zelig's from_zelig_model function to extract information from Zelig models. from_zelig_model does not appear to support models of class ", class(model)[1], ".")
     }   
   }

--- a/R/extract.R
+++ b/R/extract.R
@@ -4715,20 +4715,32 @@ setMethod("extract", signature = className("zelig", "Zelig"),
 extract.Zelig <- function(model, include.aic = TRUE, include.bic = TRUE, 
     include.loglik = TRUE, include.deviance = TRUE, include.nobs = TRUE, 
     include.censnobs = TRUE, include.wald = TRUE, ...) {
-  if ("Zelig-relogit" %in% class(model)) {
+  supported = c("Zelig-relogit", "Zelig-tobit", "Zelig-poisson",
+                "Zelig-negbin", "Zelig-logit", "Zelig-ls")
+  if ("Zelig-relogit" %in% class(model)) { # remove when users all upgrade to Zelig 5.0-16
     g <- model$zelig.out$z.out[[1]]
     class(g) <- "glm"
     e <- extract(g, include.aic = include.aic, include.bic = include.bic, 
         include.loglik = include.loglik, include.deviance = include.deviance, 
         include.nobs = include.nobs, ...)
-  } else if ("Zelig-tobit" %in% class(model)) {
+  } else if ("Zelig-tobit" %in% class(model)) { # remove when users all upgrade to Zelig 5.0-16
     e <- extract(model$zelig.out$z.out[[1]], include.aic = include.aic, 
         include.bic = include.bic, include.loglik = include.loglik, 
         include.deviance = include.deviance, include.nobs = include.nobs, 
         include.censnobs = include.censnobs, include.wald = include.wald, ...)
+  }	else if (class(model) %in% supported) {
+		if(!exists('from_zelig_model', where='package:Zelig', mode='function')){
+			stop("To extract information from a model of this class, you must install Zelig >=5.0-16")
+		}
+		mod_original <- Zelig::from_zelig_model(model)
+		e <- extract(mod_original, include.aic = include.aic, 
+		include.bic = include.bic, include.loglik = include.loglik, 
+		include.deviance = include.deviance, include.nobs = include.nobs, 
+		include.censnobs = include.censnobs, include.wald = include.wald, 
+		...)
   } else {
     stop(paste("Only the following Zelig models are currently supported:", 
-        "Zelig-relogit, Zelig-tobit."))
+        "Zelig-relogit, Zelig-tobit, Zelig-poisson, Zelig-negbin, Zelig-logit, Zelig-ls."))
   }
   return(e)
 }

--- a/R/extract.R
+++ b/R/extract.R
@@ -4719,13 +4719,13 @@ extract.Zelig <- function(model, ...) {
   } else if ("Zelig-tobit" %in% class(model)) { # remove when users all upgrade to Zelig 5.0-16
     mod_original <- model$zelig.out$z.out[[1]]
   }	else {
-	if(!exists('from_zelig_model', where = 'package:Zelig', mode = 'function')){
-		stop("texreg relies on Zelig's from_zelig_model function to extract model information. Install Zelig >= 5.0-16 to see if texreg can format your model.")
-	}
-	mod_original <- try(Zelig::from_zelig_model(model), silent = TRUE)
-    if(class(mod_original) == 'try-error'){
-		stop(paste0("texreg relies on Zelig's from_zelig_model function to extract information from Zelig models. from_zelig_model does not appear to support models of class ", class(model)[1], "."))
+    if (!exists('from_zelig_model', where = 'package:Zelig', mode = 'function')) {
+      stop("texreg relies on Zelig's from_zelig_model function to extract model information. Install Zelig >= 5.0-16 to see if texreg can format your model.")
     }
+    mod_original <- try(Zelig::from_zelig_model(model), silent = TRUE)
+    if (class(mod_original) == 'try-error') {
+      stop("texreg relies on Zelig's from_zelig_model function to extract information from Zelig models. from_zelig_model does not appear to support models of class ", class(model)[1], ".")
+    }   
   }
   e <- extract(mod_original, ...)
   return(e)

--- a/R/extract.R
+++ b/R/extract.R
@@ -4712,29 +4712,21 @@ setMethod("extract", signature = className("zelig", "Zelig"),
 
 
 # extension for Zelig objects (Zelig package >= 5.0)
-extract.Zelig <- function(model, include.aic = TRUE, include.bic = TRUE, 
-    include.loglik = TRUE, include.deviance = TRUE, include.nobs = TRUE, 
-    include.censnobs = TRUE, include.wald = TRUE, ...) {
-  supported = c("Zelig-relogit", "Zelig-tobit", "Zelig-poisson",
-                "Zelig-negbin", "Zelig-logit", "Zelig-ls", "Zelig-probit")
+extract.Zelig <- function(model, ...) {
   if ("Zelig-relogit" %in% class(model)) { # remove when users all upgrade to Zelig 5.0-16
     mod_original <- model$zelig.out$z.out[[1]]
     class(mod_original) <- "glm"
   } else if ("Zelig-tobit" %in% class(model)) { # remove when users all upgrade to Zelig 5.0-16
     mod_original <- model$zelig.out$z.out[[1]]
-  }	else if (class(model) %in% supported) {
-	if(!exists('from_zelig_model', where='package:Zelig', mode='function')){
-		stop("To extract information from a model of this class, you must install Zelig >=5.0-16")
+  }	else {
+	if(!exists('from_zelig_model', where = 'package:Zelig', mode = 'function')){
+		stop("texreg relies on Zelig's from_zelig_model function to extract model information. Install Zelig >= 5.0-16 to see if texreg can format your model.")
 	}
-	mod_original <- Zelig::from_zelig_model(model)
-  } else {
-    stop(paste("Only the following Zelig models are currently supported:", 
-        "Zelig-relogit, Zelig-tobit, Zelig-poisson, Zelig-negbin, Zelig-logit, Zelig-ls."))
-  }
-  e <- extract(mod_original, include.aic = include.aic, 
-      include.bic = include.bic, include.loglik = include.loglik, 
-      include.deviance = include.deviance, include.nobs = include.nobs, 
-      include.censnobs = include.censnobs, include.wald = include.wald, ...)
+	mod_original <- try(Zelig::from_zelig_model(model), silent = TRUE)
+    if(class(mod_original) == 'try-error'){
+		stop(paste0("texreg relies on Zelig's from_zelig_model function to extract information from Zelig models. from_zelig_model does not appear to support models of class ", class(model)[1], "."))
+    }
+  e <- extract(mod_original, ...)
   return(e)
 }
 

--- a/R/extract.R
+++ b/R/extract.R
@@ -4716,32 +4716,25 @@ extract.Zelig <- function(model, include.aic = TRUE, include.bic = TRUE,
     include.loglik = TRUE, include.deviance = TRUE, include.nobs = TRUE, 
     include.censnobs = TRUE, include.wald = TRUE, ...) {
   supported = c("Zelig-relogit", "Zelig-tobit", "Zelig-poisson",
-                "Zelig-negbin", "Zelig-logit", "Zelig-ls")
+                "Zelig-negbin", "Zelig-logit", "Zelig-ls", "Zelig-probit")
   if ("Zelig-relogit" %in% class(model)) { # remove when users all upgrade to Zelig 5.0-16
-    g <- model$zelig.out$z.out[[1]]
-    class(g) <- "glm"
-    e <- extract(g, include.aic = include.aic, include.bic = include.bic, 
-        include.loglik = include.loglik, include.deviance = include.deviance, 
-        include.nobs = include.nobs, ...)
+    mod_original <- model$zelig.out$z.out[[1]]
+    class(mod_original) <- "glm"
   } else if ("Zelig-tobit" %in% class(model)) { # remove when users all upgrade to Zelig 5.0-16
-    e <- extract(model$zelig.out$z.out[[1]], include.aic = include.aic, 
-        include.bic = include.bic, include.loglik = include.loglik, 
-        include.deviance = include.deviance, include.nobs = include.nobs, 
-        include.censnobs = include.censnobs, include.wald = include.wald, ...)
+    mod_original <- model$zelig.out$z.out[[1]]
   }	else if (class(model) %in% supported) {
-		if(!exists('from_zelig_model', where='package:Zelig', mode='function')){
-			stop("To extract information from a model of this class, you must install Zelig >=5.0-16")
-		}
-		mod_original <- Zelig::from_zelig_model(model)
-		e <- extract(mod_original, include.aic = include.aic, 
-		include.bic = include.bic, include.loglik = include.loglik, 
-		include.deviance = include.deviance, include.nobs = include.nobs, 
-		include.censnobs = include.censnobs, include.wald = include.wald, 
-		...)
+	if(!exists('from_zelig_model', where='package:Zelig', mode='function')){
+		stop("To extract information from a model of this class, you must install Zelig >=5.0-16")
+	}
+	mod_original <- Zelig::from_zelig_model(model)
   } else {
     stop(paste("Only the following Zelig models are currently supported:", 
         "Zelig-relogit, Zelig-tobit, Zelig-poisson, Zelig-negbin, Zelig-logit, Zelig-ls."))
   }
+  e <- extract(mod_original, include.aic = include.aic, 
+      include.bic = include.bic, include.loglik = include.loglik, 
+      include.deviance = include.deviance, include.nobs = include.nobs, 
+      include.censnobs = include.censnobs, include.wald = include.wald, ...)
   return(e)
 }
 

--- a/R/extract.R
+++ b/R/extract.R
@@ -4726,6 +4726,7 @@ extract.Zelig <- function(model, ...) {
     if(class(mod_original) == 'try-error'){
 		stop(paste0("texreg relies on Zelig's from_zelig_model function to extract information from Zelig models. from_zelig_model does not appear to support models of class ", class(model)[1], "."))
     }
+  }
   e <- extract(mod_original, ...)
   return(e)
 }

--- a/man/extract.Rd
+++ b/man/extract.Rd
@@ -935,6 +935,8 @@ An extract method for zelig objects from the \pkg{Zelig} package.
 
 \item{\code{Zelig}}{
 An extract method for Zelig objects from the \pkg{Zelig} package.
+
+When fitting models, \code{Zelig} often wraps additional information around a model object produced by a different \code{R} library. It is often possible to recover that model object using the \code{from_zelig_model} from \code{Zelig} (>= 5.0-16). If that underlying model is supported by \code{texreg}, tables will be produced as usual, automatically. To identify the relevant model-specific arguments (e.g., \code{include.adjrs = TRUE}), identify the class of the underlying model (\code{class(Zelig::from_zelig_model(model))}), and check the appropriate \code{extract.*} function in \code{texreg}.
 }
 
 \item{\code{zeroinfl}}{


### PR DESCRIPTION
The latest version of Zelig (only on Github so far) offers a new function ``from_zelig_model``, which allows us to extract the "original" model. For instance, when estimating a logit model, Zelig just wraps more info around a standard ``glm`` object. The new function allows us to easily recover the original model object.

Since ``texreg`` already supports many of those "underlying" models, it is trivial to add support for *many* of Zelig's models.

This PR adds logit, least squares, negative binomial, and poisson. @christophergandrud could probably help us identify other models which could be supported, simply by adding them to the ``supported`` vector of the ``extract.Zelig`` function.

```
library(Zelig)
library(texreg)
dat = read.csv('https://raw.githubusercontent.com/vincentarelbundock/Rdatasets/master/csv/HistData/Guerry.csv', 
               stringsAsFactors=FALSE)
dat$dummy = ifelse(dat$Commerce > 20, 1, 0)
m = list()
m[['poisson']] = zelig(Infanticide ~ Clergy, data=dat, model='poisson', cite=FALSE)
m[['negbin']] = zelig(dummy ~ Clergy, data=dat, model='negbin', cite=FALSE)
m[['logit']] = zelig(dummy ~ Clergy, data=dat, model='logit', cite=FALSE)
m[['relogit']] = zelig(dummy ~ Clergy, data=dat, model='relogit', cite=FALSE)
m[['ls']] = zelig(Infanticide ~ Clergy, data=dat, model='ls', cite=FALSE)
m[['tobit']] = zelig(Infanticide ~ Clergy, data=dat, model='tobit', cite=FALSE)
screenreg(m)
=================================================================================
                poisson      negbin   logit      relogit   ls         tobit      
---------------------------------------------------------------------------------
(Intercept)        3.79 ***   -0.22     1.37 **    1.32 *  44.05 ***    44.05 ***
                  (0.03)      (0.25)   (0.52)     (0.52)   (5.45)       (5.38)   
Clergy            -0.00       -0.00    -0.01      -0.01    -0.01        -0.01    
                  (0.00)      (0.00)   (0.01)     (0.01)   (0.11)       (0.11)   
Log(scale)                                                               3.21 ***
                                                                        (0.08)   
---------------------------------------------------------------------------------
AIC             1862.48      172.33    99.33      99.33                802.33    
BIC             1867.39      179.69   104.24     104.24                809.69    
Log Likelihood  -929.24      -83.16   -47.67     -47.67               -398.16    
Deviance        1399.27       36.33    95.33      95.33                 86.00    
Num. obs.         86          86       86         86       86           86       
R^2                                                         0.00                 
Adj. R^2                                                   -0.01                 
RMSE                                                       25.09                 
Total                                                                   86       
Left-censored                                                            0       
Uncensored                                                              86       
Right-censored                                                           0       
Wald Test                                                                0.01    
=================================================================================
*** p < 0.001, ** p < 0.01, * p < 0.05

```
