### PR TITLE
Add support for several Zelig 5 models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Author: Philip Leifeld
 Maintainer: Philip Leifeld <philip.leifeld@glasgow.ac.uk>
 Description: Converts coefficients, standard errors, significance stars, and goodness-of-fit statistics of statistical models into LaTeX tables or HTML tables/MS Word documents or to nicely formatted screen output for the R console for easy model comparison. A list of several models can be combined in a single table. The output is highly customizable. New model types can be easily implemented.
 URL: http://github.com/leifeld/texreg/
-Suggests: nlme, survival, network, ergm, lme4 (>= 1.0), btergm
+Suggests: nlme, survival, network, ergm, lme4 (>= 1.0), btergm, Zelig (>= 5.0-16)
 Depends: R (>= 2.15.0)
 Imports: methods, grDevices, graphics, stats
 Enhances: AER, betareg, brglm, censReg, dynlm, eha, erer, fGarch, gamlss, gee, geepack, gmm, h2o, latentnet, lmtest, lqmm, MASS, mfx, mgcv, mlogit, mnlogit, MuMIn, nnet, ordinal, plm, pscl, quantreg, relevent, rms, robustbase, RSiena, sampleSelection, simex, sna, spdep, survey, systemfit, tergm, xergm, Zelig

--- a/R/extract.R
+++ b/R/extract.R
@@ -4712,24 +4712,22 @@ setMethod("extract", signature = className("zelig", "Zelig"),
 
 
 # extension for Zelig objects (Zelig package >= 5.0)
-extract.Zelig <- function(model, include.aic = TRUE, include.bic = TRUE, 
-    include.loglik = TRUE, include.deviance = TRUE, include.nobs = TRUE, 
-    include.censnobs = TRUE, include.wald = TRUE, ...) {
-  if ("Zelig-relogit" %in% class(model)) {
-    g <- model$zelig.out$z.out[[1]]
-    class(g) <- "glm"
-    e <- extract(g, include.aic = include.aic, include.bic = include.bic, 
-        include.loglik = include.loglik, include.deviance = include.deviance, 
-        include.nobs = include.nobs, ...)
-  } else if ("Zelig-tobit" %in% class(model)) {
-    e <- extract(model$zelig.out$z.out[[1]], include.aic = include.aic, 
-        include.bic = include.bic, include.loglik = include.loglik, 
-        include.deviance = include.deviance, include.nobs = include.nobs, 
-        include.censnobs = include.censnobs, include.wald = include.wald, ...)
-  } else {
-    stop(paste("Only the following Zelig models are currently supported:", 
-        "Zelig-relogit, Zelig-tobit."))
+extract.Zelig <- function(model, ...) {
+  if ("Zelig-relogit" %in% class(model)) { # remove when users all upgrade to Zelig 5.0-16
+    mod_original <- model$zelig.out$z.out[[1]]
+    class(mod_original) <- "glm"
+  } else if ("Zelig-tobit" %in% class(model)) { # remove when users all upgrade to Zelig 5.0-16
+    mod_original <- model$zelig.out$z.out[[1]]
+  }	else {
+    if (!exists('from_zelig_model', where = 'package:Zelig', mode = 'function')) {
+      stop("texreg relies on Zelig's from_zelig_model function to extract model information. Install Zelig >= 5.0-16 to see if texreg can format your model.")
+    }
+    mod_original <- try(Zelig::from_zelig_model(model), silent = TRUE)
+    if (class(mod_original)[1] == 'try-error') {
+      stop("texreg relies on Zelig's from_zelig_model function to extract information from Zelig models. from_zelig_model does not appear to support models of class ", class(model)[1], ".")
+    }   
   }
+  e <- extract(mod_original, ...)
   return(e)
 }
 

--- a/man/extract.Rd
+++ b/man/extract.Rd
@@ -933,7 +933,7 @@ An extract method for zelig objects from the \pkg{Zelig} package.
 \item{\code{Zelig}}{
 An extract method for Zelig objects from the \pkg{Zelig} package.
 
-When fitting models, \code{Zelig} often wraps additional information around a model object produced by a different \code{R} library. It is often possible to recover that model object using the \code{from_zelig_model} from \pkg{Zelig} (>= 5.0-16). If that underlying model is supported by \code{texreg}, tables will be produced as usual, automatically. To identify the relevant model-specific arguments (e.g., \code{include.adjrs = TRUE}), identify the class of the underlying model (\code{class(Zelig::from_zelig_model(model))}), and check the appropriate \code{extract.*} function in \code{texreg}.
+When fitting models, \pkg{Zelig} often wraps additional information around a model object produced by a different \code{R} library. It is often possible to recover that model object using the \code{from_zelig_model} function from \pkg{Zelig} (>= 5.0-16). If that underlying model is supported by \code{texreg}, tables will be produced as usual, automatically. To identify the relevant model-specific arguments (e.g., \code{include.adjrs = TRUE}), identify the class of the underlying model (\code{class(Zelig::from_zelig_model(model))}), and check the appropriate \code{extract.*} function in \code{texreg}.
 }
 
 \item{\code{zeroinfl}}{

--- a/man/extract.Rd
+++ b/man/extract.Rd
@@ -933,7 +933,7 @@ An extract method for zelig objects from the \pkg{Zelig} package.
 \item{\code{Zelig}}{
 An extract method for Zelig objects from the \pkg{Zelig} package.
 
-When fitting models, \code{Zelig} often wraps additional information around a model object produced by a different \code{R} library. It is often possible to recover that model object using the \code{from_zelig_model} from \code{Zelig} (>= 5.0-16). If that underlying model is supported by \code{texreg}, tables will be produced as usual, automatically. To identify the relevant model-specific arguments (e.g., \code{include.adjrs = TRUE}), identify the class of the underlying model (\code{class(Zelig::from_zelig_model(model))}), and check the appropriate \code{extract.*} function in \code{texreg}.
+When fitting models, \code{Zelig} often wraps additional information around a model object produced by a different \code{R} library. It is often possible to recover that model object using the \code{from_zelig_model} from \pkg{Zelig} (>= 5.0-16). If that underlying model is supported by \code{texreg}, tables will be produced as usual, automatically. To identify the relevant model-specific arguments (e.g., \code{include.adjrs = TRUE}), identify the class of the underlying model (\code{class(Zelig::from_zelig_model(model))}), and check the appropriate \code{extract.*} function in \code{texreg}.
 }
 
 \item{\code{zeroinfl}}{

--- a/man/extract.Rd
+++ b/man/extract.Rd
@@ -561,10 +561,7 @@ extract(model, ...)
     include.rsquared = TRUE, include.adjrs = TRUE, 
     include.fstatistic = TRUE, ...)
 
-\S4method{extract}{Zelig}(model, include.aic = TRUE, 
-    include.bic = TRUE, include.loglik = TRUE, 
-    include.deviance = TRUE, include.nobs = TRUE, 
-    include.censnobs = TRUE, include.wald = TRUE, ...)
+\S4method{extract}{Zelig}(model, ...)
 
 \S4method{extract}{zeroinfl}(model, beside = FALSE, 
     include.count = TRUE, include.zero = TRUE, include.aic = TRUE, 
@@ -935,6 +932,8 @@ An extract method for zelig objects from the \pkg{Zelig} package.
 
 \item{\code{Zelig}}{
 An extract method for Zelig objects from the \pkg{Zelig} package.
+
+When fitting models, \code{Zelig} often wraps additional information around a model object produced by a different \code{R} library. It is often possible to recover that model object using the \code{from_zelig_model} from \code{Zelig} (>= 5.0-16). If that underlying model is supported by \code{texreg}, tables will be produced as usual, automatically. To identify the relevant model-specific arguments (e.g., \code{include.adjrs = TRUE}), identify the class of the underlying model (\code{class(Zelig::from_zelig_model(model))}), and check the appropriate \code{extract.*} function in \code{texreg}.
 }
 
 \item{\code{zeroinfl}}{


### PR DESCRIPTION
On my computer, this new PR produces the same warning (1) and notes (4) as leifeld/texreg master.

```
# Loading
library(devtools)
install_github('IQSS/Zelig')
install_github('vincentarelbundock/texreg')
library(Zelig)
library(texreg)

# Success
url = 'https://raw.githubusercontent.com/vincentarelbundock/Rdatasets/master/csv/HistData/Guerry.csv'
dat = read.csv(url, stringsAsFactors=FALSE)
dat$dummy = ifelse(dat$Commerce > 20, 1, 0)
m = list()
m[['poisson']] = zelig(Infanticide ~ Clergy, data=dat, model='poisson', cite=FALSE)
m[['negbin']] = zelig(dummy ~ Clergy, data=dat, model='negbin', cite=FALSE)
m[['logit']] = zelig(dummy ~ Clergy, data=dat, model='logit', cite=FALSE)
m[['relogit']] = zelig(dummy ~ Clergy, data=dat, model='relogit', cite=FALSE)
m[['ls']] = zelig(Infanticide ~ Clergy, data=dat, model='ls', cite=FALSE)
m[['tobit']] = zelig(Infanticide ~ Clergy, data=dat, model='tobit', cite=FALSE)
screenreg(m, include.adjrs=FALSE)

# Failure
library(ZeligChoice)
mlogit = zelig(Region ~ Clergy, data=dat, model='mlogit', cite=FALSE)
screenreg(mlogit)
```