### PR TITLE
allow custom.coef.names of pre/post omit length

### DIFF
--- a/R/texreg.R
+++ b/R/texreg.R
@@ -36,8 +36,19 @@ screenreg <- function(l, file = NULL, single.row = FALSE,
   if (!is.null(custom.coef.map)) {
     m <- custommap(m, custom.coef.map)
   } else {
-    m <- omitcoef(m, omit.coef)  #remove coefficient rows matching regex
-    m <- customnames(m, custom.coef.names)  #rename coefficients
+    n_pre_omit <- nrow(m)
+    if (length(custom.coef.names) == n_pre_omit) {
+      m <- customnames(m, custom.coef.names)  
+      m <- omitcoef(m, omit.coef)  
+    } else {
+      m <- omitcoef(m, omit.coef)  
+      n_post_omit <- nrow(m)
+      if (length(custom.coef.names) != n_post_omit) {
+        stop('Before applying `omit.coef`, there were ', n_pre_omit, ' coefficients in your table. After applying `omit.coef`, there are ', n_post_omit, '. custom.coef.names must be a string vector of length ', n_pre_omit, ' or ', n_post_omit, '.')
+      }
+      m <- omitcoef(m, omit.coef)  #remove coefficient rows matching regex
+      m <- customnames(m, custom.coef.names)  #rename coefficients
+    }
   }
   m <- rearrangeMatrix(m)  #resort matrix and conflate duplicate entries
   m <- as.data.frame(m)
@@ -297,8 +308,19 @@ texreg <- function(l, file = NULL, single.row = FALSE,
   if (!is.null(custom.coef.map)) {
     m <- custommap(m, custom.coef.map)
   } else {
-    m <- omitcoef(m, omit.coef)  #remove coefficient rows matching regex
-    m <- customnames(m, custom.coef.names)  #rename coefficients
+    n_pre_omit <- nrow(m)
+    if (length(custom.coef.names) == n_pre_omit) {
+      m <- customnames(m, custom.coef.names)  
+      m <- omitcoef(m, omit.coef)  
+    } else {
+      m <- omitcoef(m, omit.coef)  
+      n_post_omit <- nrow(m)
+      if (length(custom.coef.names) != n_post_omit) {
+        stop('Before applying `omit.coef`, there were ', n_pre_omit, ' coefficients in your table. After applying `omit.coef`, there are ', n_post_omit, '. custom.coef.names must be a string vector of length ', n_pre_omit, ' or ', n_post_omit, '.')
+      }
+      m <- omitcoef(m, omit.coef)  #remove coefficient rows matching regex
+      m <- customnames(m, custom.coef.names)  #rename coefficients
+    }
   }
   m <- rearrangeMatrix(m)  #resort matrix and conflate duplicate entries
   m <- as.data.frame(m)
@@ -761,12 +783,23 @@ htmlreg <- function(l, file = NULL, single.row = FALSE,
   if (!is.null(custom.coef.map)) {
     m <- custommap(m, custom.coef.map)
   } else {
-    m <- omitcoef(m, omit.coef)  #remove coefficient rows matching regex
-    m <- customnames(m, custom.coef.names)  #rename coefficients
+    n_pre_omit <- nrow(m)
+    if (length(custom.coef.names) == n_pre_omit) {
+      m <- customnames(m, custom.coef.names)  
+      m <- omitcoef(m, omit.coef)  
+    } else {
+      m <- omitcoef(m, omit.coef)  
+      n_post_omit <- nrow(m)
+      if (length(custom.coef.names) != n_post_omit) {
+        stop('Before applying `omit.coef`, there were ', n_pre_omit, ' coefficients in your table. After applying `omit.coef`, there are ', n_post_omit, '. custom.coef.names must be a string vector of length ', n_pre_omit, ' or ', n_post_omit, '.')
+      }
+      m <- omitcoef(m, omit.coef)  #remove coefficient rows matching regex
+      m <- customnames(m, custom.coef.names)  #rename coefficients
+    }
   }
-  m <- rearrangeMatrix(m)  # resort matrix and conflate duplicate entries
+  m <- rearrangeMatrix(m)  #resort matrix and conflate duplicate entries
   m <- as.data.frame(m)
-  
+
   modnames <- modelnames(l, models, custom.model.names)  # model names
   
   # reorder GOF and coef matrix


### PR DESCRIPTION
Before "fix" for https://github.com/leifeld/texreg/issues/24, texreg would check if the length of custom.coef.names was equal to the number of coefficients in the table **before** applying ``omit.coef``.

After the "fix", texreg checks if the length of custom.coef.names is equal to the number of coefficients in the table **after** applying ``omit.coef``.

This PR allows user to input a vector of strings of either length and prints an informative ``stop()`` message otherwise.