### PR TITLE
HTML regression tables in knitr documents

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,6 @@ URL: http://github.com/leifeld/texreg/
 BugReports: https://github.com/leifeld/texreg/issues
 Suggests: nlme, survival, network, ergm, lme4 (>= 1.0), btergm, Zelig (>= 5.0-16)
 Depends: R (>= 2.15.0)
-Imports: methods, grDevices, graphics, stats
+Imports: methods, grDevices, graphics, stats, knitr
 Enhances: AER, betareg, brglm, censReg, dynlm, eha, erer, fGarch, gamlss, gee, geepack, gmm, h2o, latentnet, lmtest, lqmm, MASS, mfx, mgcv, mlogit, mnlogit, MuMIn, nnet, ordinal, plm, pscl, quantreg, relevent, rms, robustbase, RSiena, sampleSelection, simex, sna, spdep, survey, systemfit, tergm, VGAM, xergm
 License: GPL-2 | GPL-3

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -6,6 +6,7 @@ importFrom("graphics", "axis", "mtext", "par", "plot", "points", "segments",
 importFrom("stats", "AIC", "BIC", "coef", "confint", "deviance", "extractAIC", 
     "logLik", "model.frame", "nobs", "pchisq", "pnorm", "pt", "qnorm", 
     "residuals", "summary.lm", "vcov")
+import("knitr")
 import("methods")
 export("texreg")
 export("htmlreg")

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -6,7 +6,7 @@ importFrom("graphics", "axis", "mtext", "par", "plot", "points", "segments",
 importFrom("stats", "AIC", "BIC", "coef", "confint", "deviance", "extractAIC", 
     "logLik", "model.frame", "nobs", "pchisq", "pnorm", "pt", "qnorm", 
     "residuals", "summary.lm", "vcov")
-import("knitr")
+importFrom("knitr", "knit_print", "asis_output")
 import("methods")
 export("texreg")
 export("htmlreg")
@@ -17,6 +17,7 @@ export("coeftostring")
 export("createTexreg")
 exportMethods("extract")
 S3method("print", "texregTable")
+S3method("knit_print", "htmlreg")
 export("extract.aftreg")
 export("extract.Arima")
 export("extract.averaging")

--- a/R/internal.R
+++ b/R/internal.R
@@ -1311,3 +1311,9 @@ customcolumnnames <- function(modelnames, custom.columns, custom.col.pos,
 print.texregTable <- function(x, ...) {
   cat(x, ...)
 }
+
+# print method for htmlreg
+knit_print.htmlreg <-  function(x, ...) {
+  knitr::asis_output(x)
+}
+

--- a/R/internal.R
+++ b/R/internal.R
@@ -1307,13 +1307,29 @@ customcolumnnames <- function(modelnames, custom.columns, custom.col.pos,
   }
 }
 
-# print method for texreg table strings
+# # print method for texreg table strings
 print.texregTable <- function(x, ...) {
-  cat(x, ...)
+  
+  # check whether we have an html table
+  if( "htmlreg" %in% class(x)) {
+    htmlFile <- tempfile(fileext = ".html")
+    write(x, file = htmlFile)
+    # check for RStudio
+    viewer <- getOption("viewer")
+    if (!is.null(viewer)) {
+      # use viewer if available
+      viewer(htmlFile)
+    } else {
+      # else open in browser
+      utils::browseURL(htmlFile)
+    }
+  }
+  else {cat(x, ...)}
 }
 
-# print method for htmlreg
+
+# print method for htmlreg in knitr documents
 knit_print.htmlreg <-  function(x, ...) {
-  knitr::asis_output(x)
+  asis_output(x)
 }
 

--- a/R/texreg.R
+++ b/R/texreg.R
@@ -1043,7 +1043,7 @@ htmlreg <- function(l, file = NULL, single.row = FALSE,
   }
   
   if (is.null(file) || is.na(file)) {
-    class(string) <- c("character", "texregTable")
+    class(string) <- c("character", "htmlreg", "texregTable")
     return(string)
   } else if (!is.character(file)) {
     stop("The 'file' argument must be a character string.")

--- a/R/texreg.R
+++ b/R/texreg.R
@@ -1043,7 +1043,7 @@ htmlreg <- function(l, file = NULL, single.row = FALSE,
   }
   
   if (is.null(file) || is.na(file)) {
-    class(string) <- c("character", "htmlreg", "texregTable")
+    class(string) <- c("character", "texregTable", "htmlreg")
     return(string)
   } else if (!is.character(file)) {
     stop("The 'file' argument must be a character string.")


### PR DESCRIPTION
Hi, after seeing texreg for the first time in class today, I thought it would be a nice idea if output of ``htmlreg`` could actually be displayed not just as a string but as html in knitr documents like R markdown files.

 The changes in this PR would only require one additional package dependency, ``knitr``, which most R users should have installed anyway. The result looks [like this](https://dl.dropboxusercontent.com/u/22352379/texreg_knitr.html).