### PR TITLE
extract.Zelig combines results from multiple imputation using Rubin's rules

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -4757,7 +4757,7 @@ extract.Zelig <- function(model, include.nobs = TRUE, include.nimp = TRUE, ...) 
                 class(model)[1], ".")
         }
     }
-    out <- extract(mod_original, ...)
+    out <- extract(mod_original, include.nobs = include.nobs, ...)
   }
   return(out)
 }

--- a/R/extract.R
+++ b/R/extract.R
@@ -4712,23 +4712,54 @@ setMethod("extract", signature = className("zelig", "Zelig"),
 
 
 # extension for Zelig objects (Zelig package >= 5.0)
-extract.Zelig <- function(model, ...) {
-  if ("Zelig-relogit" %in% class(model)) { # remove when users all upgrade to Zelig 5.0-16
-    mod_original <- model$zelig.out$z.out[[1]]
-    class(mod_original) <- "glm"
-  } else if ("Zelig-tobit" %in% class(model)) { # remove when users all upgrade to Zelig 5.0-16
-    mod_original <- model$zelig.out$z.out[[1]]
-  }	else {
-    if (!exists('from_zelig_model', where = 'package:Zelig', mode = 'function')) {
-      stop("texreg relies on Zelig's from_zelig_model function to extract model information. Install Zelig >= 5.0-16 to see if texreg can format your model.")
+extract.Zelig <- function(model, include.nobs = TRUE, include.nimp = TRUE, ...) {
+  if (model$mi) { 
+	if (!exists("combine_coef_se", where = "package:Zelig", 
+		mode = "function")) {
+		stop("texreg relies on Zelig's combine_coef_se function to extract model information. Install Zelig >= 5.0-17 to see if texreg can format your model.")
+	}
+    combined <- Zelig::combine_coef_se(model, messages=FALSE)
+    gof <- c(nrow(model$data), model$originaldata$m)
+    gof <- gof.names <- gof.decimal <- NULL
+    if (include.nobs) {
+      gof <- c(gof, nrow(model$data))
+      gof.names <- c(gof.names, 'Num. obs.')
+      gof.decimal <- c(gof.decimal, FALSE)
     }
-    mod_original <- try(Zelig::from_zelig_model(model), silent = TRUE)
-    if (class(mod_original)[1] == 'try-error') {
-      stop("texreg relies on Zelig's from_zelig_model function to extract information from Zelig models. from_zelig_model does not appear to support models of class ", class(model)[1], ".")
-    }   
+    if (include.nimp) {
+      gof <- c(gof, model$originaldata$m)
+      gof.names <- c(gof.names, 'Num. imp')
+      gof.decimal <- c(gof.decimal, FALSE)
+    }
+    out <- createTexreg(coef.names = names(combined[[1]]),
+                        coef = combined$coef,
+                        se = combined$se,
+                        pvalues = combined$p,
+                        gof.names = gof.names,
+                        gof = gof,
+                        gof.decimal = gof.decimal)
+  } else {
+    if ("Zelig-relogit" %in% class(model)) { # remove when users update to Zelig 5.0-16
+        mod_original <- model$zelig.out$z.out[[1]]
+        class(mod_original) <- "glm"
+    }
+    else if ("Zelig-tobit" %in% class(model)) { # remove when users update to Zelig 5.0-16
+        mod_original <- model$zelig.out$z.out[[1]]
+    }
+    else {
+        if (!exists("from_zelig_model", where = "package:Zelig", 
+            mode = "function")) {
+            stop("texreg relies on Zelig's from_zelig_model function to extract model information. Install Zelig >= 5.0-16 to see if texreg can format your model.")
+        }
+        mod_original <- try(Zelig::from_zelig_model(model), silent = TRUE)
+        if (class(mod_original)[1] == "try-error") {
+            stop("texreg relies on Zelig's from_zelig_model function to extract information from Zelig models. from_zelig_model does not appear to support models of class ", 
+                class(model)[1], ".")
+        }
+    }
+    out <- extract(mod_original, ...)
   }
-  e <- extract(mod_original, ...)
-  return(e)
+  return(out)
 }
 
 setMethod("extract", signature = className("Zelig", "Zelig"), 

--- a/R/extract.R
+++ b/R/extract.R
@@ -4731,10 +4731,10 @@ extract.Zelig <- function(model, include.nobs = TRUE, include.nimp = TRUE, ...) 
       gof.names <- c(gof.names, 'Num. imp.')
       gof.decimal <- c(gof.decimal, FALSE)
     }
-    out <- createTexreg(coef.names = names(combined[[1]]),
-                        coef = combined$coef,
-                        se = combined$se,
-                        pvalues = combined$p,
+    out <- createTexreg(coef.names = row.names(combined),
+                        coef = combined[, 'Estimate'],
+                        se = combined[, 'Std.Error'],
+                        pvalues = combined[, 'Pr(>|z|)'],
                         gof.names = gof.names,
                         gof = gof,
                         gof.decimal = gof.decimal)

--- a/R/extract.R
+++ b/R/extract.R
@@ -4718,7 +4718,7 @@ extract.Zelig <- function(model, include.nobs = TRUE, include.nimp = TRUE, ...) 
         mode = "function")) {
       stop("texreg relies on Zelig's combine_coef_se function to extract model information. Install Zelig >= 5.0-17 to see if texreg can format your model.")
     }
-    combined <- Zelig::combine_coef_se(model, messages=FALSE)
+    combined <- Zelig::combine_coef_se(model, messages = FALSE)
     gof <- c(nrow(model$data), model$originaldata$m)
     gof <- gof.names <- gof.decimal <- NULL
     if (include.nobs) {
@@ -4728,7 +4728,7 @@ extract.Zelig <- function(model, include.nobs = TRUE, include.nimp = TRUE, ...) 
     }
     if (include.nimp) {
       gof <- c(gof, model$originaldata$m)
-      gof.names <- c(gof.names, 'Num. imp')
+      gof.names <- c(gof.names, 'Num. imp.')
       gof.decimal <- c(gof.decimal, FALSE)
     }
     out <- createTexreg(coef.names = names(combined[[1]]),
@@ -4745,8 +4745,7 @@ extract.Zelig <- function(model, include.nobs = TRUE, include.nimp = TRUE, ...) 
     }
     else if ("Zelig-tobit" %in% class(model)) { # remove when users update to Zelig 5.0-16
       mod_original <- model$zelig.out$z.out[[1]]
-    }
-    else {
+    } else {
       if (!exists("from_zelig_model", where = "package:Zelig", 
           mode = "function")) {
         stop("texreg relies on Zelig's from_zelig_model function to extract model information. Install Zelig >= 5.0-16 to see if texreg can format your model.")

--- a/R/extract.R
+++ b/R/extract.R
@@ -4714,10 +4714,10 @@ setMethod("extract", signature = className("zelig", "Zelig"),
 # extension for Zelig objects (Zelig package >= 5.0)
 extract.Zelig <- function(model, include.nobs = TRUE, include.nimp = TRUE, ...) {
   if (model$mi) { 
-	if (!exists("combine_coef_se", where = "package:Zelig", 
-		mode = "function")) {
-		stop("texreg relies on Zelig's combine_coef_se function to extract model information. Install Zelig >= 5.0-17 to see if texreg can format your model.")
-	}
+    if (!exists("combine_coef_se", where = "package:Zelig", 
+        mode = "function")) {
+      stop("texreg relies on Zelig's combine_coef_se function to extract model information. Install Zelig >= 5.0-17 to see if texreg can format your model.")
+    }
     combined <- Zelig::combine_coef_se(model, messages=FALSE)
     gof <- c(nrow(model$data), model$originaldata$m)
     gof <- gof.names <- gof.decimal <- NULL
@@ -4740,22 +4740,22 @@ extract.Zelig <- function(model, include.nobs = TRUE, include.nimp = TRUE, ...) 
                         gof.decimal = gof.decimal)
   } else {
     if ("Zelig-relogit" %in% class(model)) { # remove when users update to Zelig 5.0-16
-        mod_original <- model$zelig.out$z.out[[1]]
-        class(mod_original) <- "glm"
+      mod_original <- model$zelig.out$z.out[[1]]
+      class(mod_original) <- "glm"
     }
     else if ("Zelig-tobit" %in% class(model)) { # remove when users update to Zelig 5.0-16
-        mod_original <- model$zelig.out$z.out[[1]]
+      mod_original <- model$zelig.out$z.out[[1]]
     }
     else {
-        if (!exists("from_zelig_model", where = "package:Zelig", 
-            mode = "function")) {
-            stop("texreg relies on Zelig's from_zelig_model function to extract model information. Install Zelig >= 5.0-16 to see if texreg can format your model.")
-        }
-        mod_original <- try(Zelig::from_zelig_model(model), silent = TRUE)
-        if (class(mod_original)[1] == "try-error") {
-            stop("texreg relies on Zelig's from_zelig_model function to extract information from Zelig models. from_zelig_model does not appear to support models of class ", 
-                class(model)[1], ".")
-        }
+      if (!exists("from_zelig_model", where = "package:Zelig", 
+          mode = "function")) {
+        stop("texreg relies on Zelig's from_zelig_model function to extract model information. Install Zelig >= 5.0-16 to see if texreg can format your model.")
+      }
+      mod_original <- try(Zelig::from_zelig_model(model), silent = TRUE)
+      if (class(mod_original)[1] == "try-error") {
+        stop("texreg relies on Zelig's from_zelig_model function to extract information from Zelig models. from_zelig_model does not appear to support models of class ", 
+               class(model)[1], ".")
+      }
     }
     out <- extract(mod_original, include.nobs = include.nobs, ...)
   }

--- a/man/extract.Rd
+++ b/man/extract.Rd
@@ -561,7 +561,8 @@ extract(model, ...)
     include.rsquared = TRUE, include.adjrs = TRUE, 
     include.fstatistic = TRUE, ...)
 
-\S4method{extract}{Zelig}(model, ...)
+\S4method{extract}{Zelig}(model, include.nobs = TRUE, 
+                          include.nimp = TRUE, ...)
 
 \S4method{extract}{zeroinfl}(model, beside = FALSE, 
     include.count = TRUE, include.zero = TRUE, include.aic = TRUE, 
@@ -934,6 +935,8 @@ An extract method for zelig objects from the \pkg{Zelig} package.
 An extract method for Zelig objects from the \pkg{Zelig} package.
 
 When fitting models, \pkg{Zelig} often wraps additional information around a model object produced by a different \code{R} library. It is often possible to recover that model object using the \code{from_zelig_model} function from \pkg{Zelig} (>= 5.0-16). If that underlying model is supported by \code{texreg}, tables will be produced as usual, automatically. To identify the relevant model-specific arguments (e.g., \code{include.adjrs = TRUE}), identify the class of the underlying model (\code{class(Zelig::from_zelig_model(model))}), and check the appropriate \code{extract.*} function in \code{texreg}.
+
+When working with models estimated by \pkg{Zelig} using data processed by multiple imputation, \pkg{texreg} will automatically combine coefficients and standard errors using Rubin's rules, as encoded in the \pkg{Zelig}'s (>= 5.0-16) \code{combine_coef_se} function.
 }
 
 \item{\code{zeroinfl}}{
@@ -978,6 +981,7 @@ An extract method for zeroinfl objects from the \pkg{pscl} package.
 \item{include.missings}{ If available: should the number of missing observations be reported (in survival models)? }
 \item{include.mse}{If available: should the mean square error be reported? }
 \item{include.nagelkerke}{ If available: should Nagelkerke's R-squared be reported? }
+\item{include.nimp}{ If available: should the number of multiple imputations be reported (in Zelig models with imputed data)?}
 \item{include.nobs}{ If available: should the number of observations be reported? }
 \item{include.nsmooth}{ If available: should the number of smooth terms be reported (in GAMs)? }
 \item{include.nvertices}{ If available: should the number of vertices be reported in a statistical network model? }

--- a/man/extract.Rd
+++ b/man/extract.Rd
@@ -936,7 +936,7 @@ An extract method for Zelig objects from the \pkg{Zelig} package.
 
 When fitting models, \pkg{Zelig} often wraps additional information around a model object produced by a different \code{R} library. It is often possible to recover that model object using the \code{from_zelig_model} function from \pkg{Zelig} (>= 5.0-16). If that underlying model is supported by \code{texreg}, tables will be produced as usual, automatically. To identify the relevant model-specific arguments (e.g., \code{include.adjrs = TRUE}), identify the class of the underlying model (\code{class(Zelig::from_zelig_model(model))}), and check the appropriate \code{extract.*} function in \code{texreg}.
 
-When working with models estimated by \pkg{Zelig} using data processed by multiple imputation, \pkg{texreg} will automatically combine coefficients and standard errors using Rubin's rules, as encoded in the \pkg{Zelig}'s (>= 5.0-16) \code{combine_coef_se} function.
+When working with models estimated by \pkg{Zelig} using data processed by multiple imputation, \pkg{texreg} will automatically combine coefficients and standard errors using Rubin's rules, as encoded in \pkg{Zelig}'s (>= 5.0-16) \code{combine_coef_se} function.
 }
 
 \item{\code{zeroinfl}}{


### PR DESCRIPTION
Depends on Zelig 5.0-17 (github only so far, I think).

@christophergandrud might care about this.

```
> library(pacman)
> p_load(mice, Zelig, Amelia, texreg)
> data(nhanes)
> imp = Amelia::amelia(nhanes, p2s=0)
> models = list()
> models[['MI']] = Zelig::zelig(age ~ hyp, data=imp, model='poisson', cite=FALSE)
> models[['LWD']] = Zelig::zelig(age ~ hyp, data=imp$imputations[[1]], model='poisson', cite=FALSE)
> screenreg(models, include.nobs=FALSE)

===============================
                MI      LWD    
-------------------------------
(Intercept)     -0.09     0.01 
                (0.49)   (0.49)
hyp              0.51     0.42 
                (0.35)   (0.34)
-------------------------------
Num. imp         5             
AIC                      72.00 
BIC                      74.43 
Log Likelihood          -34.00 
Deviance                  7.75 
===============================
*** p < 0.001, ** p < 0.01, * p < 0.05
```