### PR TITLE
Omit rename

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -482,6 +482,7 @@ aggregate.matrix <- function(models, gof.names, custom.gof.names, digits,
 }
 
 
+# function to apply the omit.coef and custom.coef.names operations
 omit_rename <- function(m, omit.coef, custom.coef.names) {
   # omit
   if (!is.null(omit.coef)) {

--- a/R/internal.R
+++ b/R/internal.R
@@ -515,7 +515,7 @@ omit_rename <- function(m, omit.coef, custom.coef.names) {
       custom.coef.names <- custom.coef.names[idx]
     } 
   } else {
-    custom.coef.names = row.names(m)[idx]
+    custom.coef.names <- row.names(m)[idx]
   }
 
   # output

--- a/R/internal.R
+++ b/R/internal.R
@@ -482,48 +482,44 @@ aggregate.matrix <- function(models, gof.names, custom.gof.names, digits,
 }
 
 
-# use custom coefficient names if provided
-customnames <- function(m, custom.names) {
-  if (is.null(custom.names)) {
-    return(m)
-  } else if (length(custom.names) > 1) {
-    if (!class(custom.names) == "character") {
-      stop("Custom coefficient names must be provided as a vector of strings!")
-    } else if (length(custom.names) != length(rownames(m))) {
-      stop(paste("There are", length(rownames(m)), 
-          "coefficients, but you provided", length(custom.names), 
-          "custom names for them."))
-    } else {
-      custom.names[is.na(custom.names)] <- rownames(m)[is.na(custom.names)]
-      rownames(m) <- custom.names
-    }
-  } else if (!is.na(custom.names) & class(custom.names) != "character") {
-    stop("Custom coefficient names must be provided as a vector of strings.")
-  } else if (length(custom.names) == 1 & class(custom.names) == "character"
-      & is.na(custom.names)) {
-    rownames(m) <- custom.names
-  } else if (length(custom.names) == length(rownames(m))) {
-    rownames(m) <- custom.names
-  }
-  return(m)
-}
-
-
-# remove coefficient rows that match the omit.coef regular expression
-omitcoef <- function(m, omit.coef) {
+omit_rename <- function(m, omit.coef, custom.coef.names) {
+  # omit
   if (!is.null(omit.coef)) {
     if (!is.character(omit.coef) || is.na(omit.coef)) {
-      stop("omit.coef must be a character string!")
+      stop("omit.coef must be a character string.")
     }
-    remove.rows <- grep(omit.coef, rownames(m))
-    if (length(remove.rows) == 0) {
-      return(m)
-    } else if (length(remove.rows) == nrow(m)) {
+    idx <- !grepl(omit.coef, row.names(m))
+    if (all(!idx)) {
       stop("You were trying to remove all coefficients using omit.coef.")
-    } else {
-      m <- m[-remove.rows, ]
     }
+  } else {
+    idx <- rep(TRUE, nrow(m))
   }
+  
+  # rename
+  if (!is.null(custom.coef.names)) {
+    if (!class(custom.coef.names) == "character") { # check type
+      stop("custom.coef.names must be a vector of strings.")
+    }
+    if (!length(custom.coef.names) %in% c(nrow(m), sum(idx))) { # check length
+      if (is.null(omit.coef)) {
+        stop("custom.coef.names must be a string vector of length ", nrow(m), '.')
+      } else {
+        stop("custom.coef.names must be a string vector of length ", sum(idx), ' or ', nrow(m), '.')
+      }
+    }
+    if (length(custom.coef.names) == sum(idx)) { # user submits number of custom names after omission
+      custom.coef.names <- custom.coef.names 
+    } else { # user submits number of custom names before omission
+      custom.coef.names <- custom.coef.names[idx]
+    } 
+  } else {
+    custom.coef.names = row.names(m)[idx]
+  }
+
+  # output
+  m <- m[idx, ]
+  row.names(m) <- custom.coef.names
   return(m)
 }
 

--- a/R/internal.R
+++ b/R/internal.R
@@ -502,7 +502,7 @@ omit_rename <- function(m, omit.coef, custom.coef.names) {
       stop("custom.coef.names must be a vector of strings.")
     }
     if (!length(custom.coef.names) %in% c(nrow(m), sum(idx))) { # check length
-      if (is.null(omit.coef)) {
+      if (nrow(m) == sum(idx)) {
         stop("custom.coef.names must be a string vector of length ", nrow(m), '.')
       } else {
         stop("custom.coef.names must be a string vector of length ", sum(idx), ' or ', nrow(m), '.')

--- a/R/texreg.R
+++ b/R/texreg.R
@@ -36,8 +36,7 @@ screenreg <- function(l, file = NULL, single.row = FALSE,
   if (!is.null(custom.coef.map)) {
     m <- custommap(m, custom.coef.map)
   } else {
-    m <- omitcoef(m, omit.coef)  #remove coefficient rows matching regex
-    m <- customnames(m, custom.coef.names)  #rename coefficients
+    m <- omit_rename(m, omit.coef = omit.coef, custom.coef.names = custom.coef.names)
   }
   m <- rearrangeMatrix(m)  #resort matrix and conflate duplicate entries
   m <- as.data.frame(m)
@@ -297,8 +296,7 @@ texreg <- function(l, file = NULL, single.row = FALSE,
   if (!is.null(custom.coef.map)) {
     m <- custommap(m, custom.coef.map)
   } else {
-    m <- omitcoef(m, omit.coef)  #remove coefficient rows matching regex
-    m <- customnames(m, custom.coef.names)  #rename coefficients
+    m <- omit_rename(m, omit.coef = omit.coef, custom.coef.names = custom.coef.names)
   }
   m <- rearrangeMatrix(m)  #resort matrix and conflate duplicate entries
   m <- as.data.frame(m)
@@ -761,8 +759,7 @@ htmlreg <- function(l, file = NULL, single.row = FALSE,
   if (!is.null(custom.coef.map)) {
     m <- custommap(m, custom.coef.map)
   } else {
-    m <- omitcoef(m, omit.coef)  #remove coefficient rows matching regex
-    m <- customnames(m, custom.coef.names)  #rename coefficients
+    m <- omit_rename(m, omit.coef = omit.coef, custom.coef.names = custom.coef.names)
   }
   m <- rearrangeMatrix(m)  # resort matrix and conflate duplicate entries
   m <- as.data.frame(m)


### PR DESCRIPTION
This replaces the ``omitcoef`` and ``customnames`` by a single ``omit_rename`` function. During our previous exchange, it became clear that these two operations must be integrated if we want to allow users to submit vectors of custom.names of different lengths based on number of coefficients before/after omission.

```
library(texreg)
url = 'https://raw.githubusercontent.com/vincentarelbundock/Rdatasets/master/csv/HistData/Guerry.csv'
dat = read.csv(url, stringsAsFactors=FALSE)
models = list()
models[['All Donations']] = lm(Literacy ~ Donations + Region, dat)
models[['Clergy Donations']] = lm(Literacy ~ Donation_clergy + Region, dat)

ccn0 = c('bad', 'example')
ccn1 = letters[1:7]
ccn2 = c('Intercept', 'Donations', 'Donations')

# Working examples
screenreg(models, custom.coef.names=ccn1, omit.coef='Region')
screenreg(models, custom.coef.names=ccn2, omit.coef='Region')
screenreg(models, custom.coef.names=ccn1)

# Bad examples (with informative warning)
screenreg(models, custom.coef.names=ccn0, omit.coef='Region')
screenreg(models, custom.coef.names=ccn2)
```