### PR TITLE
Fixed extract.ols issue with include.rsquared = F & include.adjrs = T

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -3143,7 +3143,7 @@ extract.ols <- function (model, include.nobs = TRUE, include.rsquared = TRUE,
     gof.decimal <- c(gof.decimal, TRUE)
   }
   if (include.adjrs == TRUE) {
-    adj <- 1 - (1 - rs) * (n - 1)/(n - model$stats["d.f."] - 1)
+    adj <- 1 - (1 - model$stats["R2"]) * (n - 1)/(n - model$stats["d.f."] - 1)
     gof <- c(gof, adj)
     gof.names <- c(gof.names, "Adj.\ R$^2$")
     gof.decimal <- c(gof.decimal, TRUE)

--- a/R/extract.R
+++ b/R/extract.R
@@ -3143,7 +3143,7 @@ extract.ols <- function (model, include.nobs = TRUE, include.rsquared = TRUE,
     gof.decimal <- c(gof.decimal, TRUE)
   }
   if (include.adjrs == TRUE) {
-    adj <- 1 - (1 - model$stats["R2"]) * (n - 1)/(n - model$stats["d.f."] - 1)
+    adj <- 1 - (1 - model$stats["R2"]) * (n - 1) / (n - model$stats["d.f."] - 1)
     gof <- c(gof, adj)
     gof.names <- c(gof.names, "Adj.\ R$^2$")
     gof.decimal <- c(gof.decimal, TRUE)


### PR DESCRIPTION
There was a small issue with the `extract.ols()` function where the option `include.rsquared = F` with simultaneous `include.adjrs = T` would throw an error because the `rs` object is only defined within the the  `if (include.rsquared== TRUE)` condition. I modified the code so that    `if (include.adjrs == TRUE)` directly pulls the R2 from the model stats. 

See #51 
