### PR TITLE
Bugfix huxtablereg by using eval.parent. Scary NSE.

### DIFF
--- a/R/texreg.R
+++ b/R/texreg.R
@@ -515,7 +515,7 @@ huxtablereg <- function(l,
   mr.call[[1L]] <- quote(texreg::matrixreg)
   mr.call$include.attributes <- TRUE
   mr.call$trim <- TRUE
-  mx <- eval(mr.call)
+  mx <- eval.parent(mr.call)
 
   gof.names <- attr(mx, "gof.names")
   coef.names <- attr(mx, "coef.names")

--- a/tests/testthat/test-huxtablereg.R
+++ b/tests/testthat/test-huxtablereg.R
@@ -14,13 +14,12 @@ test_that("huxtablereg gives useful error message if huxtable not installed", {
   })
 })
 
-# WORKS
+
 test_that("screenreg works", {
   expect_known_output(screenreg(list(m1, m2)), file = "../files/screenreg.RDS")
 })
 
 
-# FAILS
 test_that("huxtablereg works", {
   hr <- huxtablereg(list(m1, m2))
   expect_known_output(hr, 

--- a/tests/testthat/test-huxtablereg.R
+++ b/tests/testthat/test-huxtablereg.R
@@ -14,15 +14,7 @@ test_that("huxtablereg gives useful error message if huxtable not installed", {
   })
 })
 
-
-test_that("screenreg works", {
-  expect_known_output(screenreg(list(m1, m2)), file = "../files/screenreg.RDS")
-})
-
-
 test_that("huxtablereg works", {
-  hr <- huxtablereg(list(m1, m2))
-  expect_known_output(hr, 
-        file = "../files/huxtablereg.RDS")
+  expect_known_output(huxtablereg(list(m1, m2)),
+                      file = "../files/huxtablereg.RDS")
 })
-

--- a/tests/testthat/test-huxtablereg.R
+++ b/tests/testthat/test-huxtablereg.R
@@ -14,16 +14,16 @@ test_that("huxtablereg gives useful error message if huxtable not installed", {
   })
 })
 
-# # WORKS
-# test_that("screenreg works", {
-#   expect_equal(output <- screenreg(list(m1, m2)),
-#                readRDS("../files/screenreg2.RDS"))
-# })
-# # saveRDS(output, "../files/screenreg2.RDS")
-#
-# # FAILS
-# test_that("huxtablereg works", {
-#   expect_equal(output <- huxtablereg(list(m1, m2)),
-#                readRDS("../files/huxtablereg.RDS"))
-# })
-# # saveRDS(output, "../files/huxtablereg.RDS")
+# WORKS
+test_that("screenreg works", {
+  expect_known_output(screenreg(list(m1, m2)), file = "../files/screenreg.RDS")
+})
+
+
+# FAILS
+test_that("huxtablereg works", {
+  hr <- huxtablereg(list(m1, m2))
+  expect_known_output(hr, 
+        file = "../files/huxtablereg.RDS")
+})
+


### PR DESCRIPTION
Uses `eval.parent` to fix the bug uncovered by testing. Also tweaks the tests to use `expect_known_output`, which seems easier on my machine