### PR TITLE
Make felm statistics for projected model optional

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: texreg
-Version: 1.37.6
+Version: 1.37.7
 Date: 2020-08-19
 Title: Conversion of R Regression Output to LaTeX or HTML Tables
 Authors@R: c(person(given = "Philip", family = "Leifeld", email = "philip.leifeld@essex.ac.uk", role = c("aut", "cre")),

--- a/R/extract.R
+++ b/R/extract.R
@@ -1875,6 +1875,7 @@ extract.felm <- function(model,
                          include.rsquared = TRUE,
                          include.adjrs = TRUE,
                          include.fstatistic = FALSE,
+                         include.proj.stats = TRUE,
                          include.groups = TRUE,
                          ...) {
 
@@ -1893,23 +1894,39 @@ extract.felm <- function(model,
     gof.decimal <- c(gof.decimal, FALSE)
   }
   if (include.rsquared == TRUE) {
-    gof <- c(gof, s$r2, s$P.r.squared)
-    gof.names <- c(gof.names, "R$^2$ (full model)", "R$^2$ (proj model)")
-    gof.decimal <- c(gof.decimal, TRUE, TRUE)
+    gof <- c(gof, s$r2)
+    gof.decimal <- c(gof.decimal, TRUE)
+    if (include.proj.stats == TRUE) {
+      gof <- c(gof, s$P.r.squared)
+      gof.decimal <- c(gof.decimal, TRUE)
+      gof.names <- c(gof.names, "R$^2$ (full model)", "R$^2$ (proj model)")
+    } else {
+      gof.names <- c(gof.names, "R$^2$")
+    }
   }
   if (include.adjrs == TRUE) {
-    gof <- c(gof, s$r2adj, s$P.adj.r.squared)
-    gof.names <- c(gof.names, "Adj. R$^2$ (full model)",
-                   "Adj. R$^2$ (proj model)")
-    gof.decimal <- c(gof.decimal, TRUE, TRUE)
+    gof <- c(gof, s$r2adj)
+    gof.decimal <- c(gof.decimal, TRUE)
+    if (include.proj.stats == TRUE) {
+      gof <- c(gof, s$P.adj.r.squared)
+      gof.decimal <- c(gof.decimal, TRUE)
+      gof.names <- c(gof.names, "Adj. R$^2$ (full model)", "Adj. R$^2$ (proj model)")
+    } else {
+      gof.names <- c(gof.names, "Adj. R$^2$")
+    }
   }
   if (include.fstatistic == TRUE) {
-    gof <- c(gof, s$F.fstat[1], s$F.fstat[4],
-             s$P.fstat[length(s$P.fstat) - 1], s$P.fstat[1])
-    gof.names <- c(gof.names, "F statistic (full model)",
-                   "F (full model): p-value", "F statistic (proj model)",
-                   "F (proj model): p-value")
-    gof.decimal <- c(gof.decimal, TRUE, TRUE, TRUE, TRUE)
+    gof <- c(gof, s$F.fstat[1], s$F.fstat[4])
+    gof.decimal <- c(gof.decimal, TRUE, TRUE)
+    if (include.proj.stats == TRUE) {
+      gof <- c(gof, s$P.fstat[length(s$P.fstat) - 1], s$P.fstat[1])
+      gof.decimal <- c(gof.decimal, TRUE, TRUE)
+      gof.names <- c(gof.names, "F statistic (full model)",
+                     "F (full model): p-value", "F statistic (proj model)",
+                     "F (proj model): p-value")
+    } else {
+      gof.names <- c(gof.names, "F statistic", "F p-value")
+    }
   }
   if (include.groups == TRUE && length(s$fe) > 0) {
     grp <- sapply(s$fe, function(x) length(levels(x)))
@@ -1941,6 +1958,7 @@ extract.felm <- function(model,
 #' @param include.rsquared Report R^2 in the GOF block?
 #' @param include.adjrs Report adjusted R^2 in the GOF block?
 #' @param include.fstatistic Report the F-statistic in the GOF block?
+#' @param include.proj.stats Include statistics for projected model in the GOF block?
 #' @param include.groups Report the number of groups?
 #' @param ... Custom parameters, which are handed over to subroutines, in this
 #'   case to the \code{summary} method for the object.

--- a/man/extract-felm-method.Rd
+++ b/man/extract-felm-method.Rd
@@ -11,6 +11,7 @@
   include.rsquared = TRUE,
   include.adjrs = TRUE,
   include.fstatistic = FALSE,
+  include.proj.stats = TRUE,
   include.groups = TRUE,
   ...
 )
@@ -25,6 +26,8 @@
 \item{include.adjrs}{Report adjusted R^2 in the GOF block?}
 
 \item{include.fstatistic}{Report the F-statistic in the GOF block?}
+
+\item{include.proj.stats}{Include statistics for projected model in the GOF block?}
 
 \item{include.groups}{Report the number of groups?}
 

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -230,6 +230,11 @@ test_that("extract felm objects from the lfe package", {
   expect_equivalent(which(tr@pvalues < 0.05), 1:2)
   expect_equivalent(which(tr@gof.decimal), 2:5)
 
+  # check exclusion of projected model statistics
+  tr <- extract(est, include.proj.stats = FALSE)
+  expect_length(tr@gof.names, 5)
+  expect_false(any(grepl('proj model', tr@gof.names, fixed = TRUE)))
+
   # without fixed effects
   OLS1 <- felm(Sepal.Length ~ Sepal.Width |0|0|0, data = iris)
   tr1 <- extract(OLS1)


### PR DESCRIPTION
The extract method for the lfe package includes statistics (e.g. R-squared) for the projected model in the GOF block.

This commit adds a parameter to extract.felm that allows users to exclude statistics for the projected model. The default behavior, however, is unchanged so users will not see different output after updating unless they use the new `include.proj.stats` parameter.

Usage example...

```r
library(lfe)
mdl <- felm(Sepal.Length ~ Sepal.Width | Species, data=iris)
texreg(list(mdl), include.proj.stats = FALSE)
```