### PR TITLE
Add a quartoreg function

### DIFF
--- a/R/texreg.R
+++ b/R/texreg.R
@@ -766,6 +766,11 @@ quartoreg <- function(...) {
     texreg(..., use.packages = FALSE) # do not print \usepackage{dcolumn} etc.
   } else if(knitr::is_html_output()) {
     htmlreg(..., doctype = FALSE, star.symbol = "&#42;") # the star symbol must be escaped in Markdown
+  } else if("docx" %in% knitr::opts_knit$get("rmarkdown.pandoc.to")) {
+    mr <- matrixreg(..., output.type = "ascii", include.attributes = FALSE, trim = TRUE)
+    colnames(mr) <- mr[1, ] # set column names because we want 'kable' to draw a horizontal  line under the model names
+    mr <- mr[-1, ] # remove the first row because we already set the model names as column names
+    knitr::kable(mr) # use the kable function to render the table in the Word document
   } else { # whatever else knitr is throwing our way should prompt an ASCII table
     screenreg(...)
   }

--- a/R/texreg.R
+++ b/R/texreg.R
@@ -697,85 +697,6 @@ knitreg <- function(...) {
   }
 }
 
-#' Flexibly choose the right table output format for use with \pkg{knitr}
-#'
-#' Flexibly choose the right table output format for use with \pkg{knitr}.
-#'
-#' This function automatically selects the right function (\link{texreg},
-#' \link{screenreg}, \link{htmlreg}, or \link{matrixreg}) with the right set of
-#' arguments for use with the \pkg{knitr} package, for example in RStudio. The
-#' advantage of using this function with \pkg{knitr} is that the user does not
-#' need to replace the \link{texreg}, \link{htmlreg} etc. function call in the
-#' document when a different output format is selected.
-#'
-#' \link{knitreg} works with...
-#' \itemize{
-#'   \item \R HTML documents (\code{.Rhtml} extension)
-#'   \item \R Sweave documents (\code{.Rnw} extension) for PDF output via LaTeX,
-#'     rendered using...
-#'     \itemize{
-#'       \item the \pkg{knitr} package
-#'       \item the \pkg{Sweave} package
-#'     }
-#'   \item \R Markdown documents (\code{.Rmd} extension), rendered as...
-#'     \itemize{
-#'       \item HTML documents
-#'       \item PDF documents
-#'       \item Word documents
-#'       \item Powerpoint presentations
-#'       \item Presentations (\code{.Rpres} extension, not \code{.Rmd})
-#'     }
-#'   \item \R Notebooks, including preview
-#' }
-#'
-#' If Markdown and HTML rendering are selected, \link{htmlreg} arguments
-#' \code{doctype = FALSE} and \code{star.symbol = "&#42;"} are set to enable
-#' compatibility with Markdown. With \R HTML documents (but not Markdown) or
-#' presentations (\code{.Rpres} extension), only \code{doctype = FALSE} is set.
-#'
-#' For PDF/LaTeX documents, the \link{texreg} argument
-#' \code{use.packages = FALSE} is set to suppress any package loading
-#' instructions in the preamble. The user must load any packages manually in the
-#' preamble of the document.
-#'
-#' The \pkg{knitr} and \pkg{rmarkdown} packages must be installed for this
-#' function to work.
-#'
-#' @param ... Arguments to be handed over to the \link{texreg}, \link{htmlreg},
-#'   \link{screenreg}, or \link{matrixreg} function. See the respective help
-#'   page for details.
-#' @return A table as a \code{character} string in the respective output format.
-#'
-#' @author Philip Leifeld, with input from David Hugh-Jones
-#' @family texreg
-#' @seealso \code{\link{texreg-package}} \code{\link{extract}}
-#'
-#' @examples
-#' require("nlme")
-#' model.1 <- lme(distance ~ age, data = Orthodont, random = ~ 1)
-#' model.2 <- lme(distance ~ age + Sex, data = Orthodont, random = ~ 1)
-#' knitreg(list(model.1, model.2), center = FALSE, caption = "", table = FALSE)
-#'
-#' @export
-quartoreg <- function(...) {
-  if (!requireNamespace("knitr", quietly = TRUE)) {
-    stop("knitreg requires the 'knitr' package to be installed.\n",
-         "To do this, enter 'install.packages(\"knitr\")'.")
-  }
-  if(knitr::is_latex_output()) {
-    texreg(..., use.packages = FALSE) # do not print \usepackage{dcolumn} etc.
-  } else if(knitr::is_html_output()) {
-    htmlreg(..., doctype = FALSE, star.symbol = "&#42;") # the star symbol must be escaped in Markdown
-  } else if("docx" %in% knitr::opts_knit$get("rmarkdown.pandoc.to")) {
-    mr <- matrixreg(..., output.type = "ascii", include.attributes = FALSE, trim = TRUE)
-    colnames(mr) <- mr[1, ] # set column names because we want 'kable' to draw a horizontal  line under the model names
-    mr <- mr[-1, ] # remove the first row because we already set the model names as column names
-    knitr::kable(mr) # use the kable function to render the table in the Word document
-  } else { # whatever else knitr is throwing our way should prompt an ASCII table
-    screenreg(...)
-  }
-}
-
 #' Convert regression output to a \code{character} matrix
 #'
 #' Conversion of \R regression output to a \code{character} matrix.
@@ -2659,6 +2580,87 @@ plotreg <- function(l,
     ggplot2::ggsave(filename = file, plot = p)
   }
 }
+
+
+#' Flexibly choose the right table output format for use with \pkg{knitr}
+#'
+#' Flexibly choose the right table output format for use with \pkg{knitr}.
+#'
+#' This function automatically selects the right function (\link{texreg},
+#' \link{screenreg}, \link{htmlreg}, or \link{matrixreg}) with the right set of
+#' arguments for use with the \pkg{knitr} package, for example in RStudio. The
+#' advantage of using this function with \pkg{knitr} is that the user does not
+#' need to replace the \link{texreg}, \link{htmlreg} etc. function call in the
+#' document when a different output format is selected.
+#'
+#' \link{knitreg} works with...
+#' \itemize{
+#'   \item \R HTML documents (\code{.Rhtml} extension)
+#'   \item \R Sweave documents (\code{.Rnw} extension) for PDF output via LaTeX,
+#'     rendered using...
+#'     \itemize{
+#'       \item the \pkg{knitr} package
+#'       \item the \pkg{Sweave} package
+#'     }
+#'   \item \R Markdown documents (\code{.Rmd} extension), rendered as...
+#'     \itemize{
+#'       \item HTML documents
+#'       \item PDF documents
+#'       \item Word documents
+#'       \item Powerpoint presentations
+#'       \item Presentations (\code{.Rpres} extension, not \code{.Rmd})
+#'     }
+#'   \item \R Notebooks, including preview
+#' }
+#'
+#' If Markdown and HTML rendering are selected, \link{htmlreg} arguments
+#' \code{doctype = FALSE} and \code{star.symbol = "&#42;"} are set to enable
+#' compatibility with Markdown. With \R HTML documents (but not Markdown) or
+#' presentations (\code{.Rpres} extension), only \code{doctype = FALSE} is set.
+#'
+#' For PDF/LaTeX documents, the \link{texreg} argument
+#' \code{use.packages = FALSE} is set to suppress any package loading
+#' instructions in the preamble. The user must load any packages manually in the
+#' preamble of the document.
+#'
+#' The \pkg{knitr} and \pkg{rmarkdown} packages must be installed for this
+#' function to work.
+#'
+#' @param ... Arguments to be handed over to the \link{texreg}, \link{htmlreg},
+#'   \link{screenreg}, or \link{matrixreg} function. See the respective help
+#'   page for details.
+#' @return A table as a \code{character} string in the respective output format.
+#'
+#' @author Philip Leifeld, with input from David Hugh-Jones
+#' @family texreg
+#' @seealso \code{\link{texreg-package}} \code{\link{extract}}
+#'
+#' @examples
+#' require("nlme")
+#' model.1 <- lme(distance ~ age, data = Orthodont, random = ~ 1)
+#' model.2 <- lme(distance ~ age + Sex, data = Orthodont, random = ~ 1)
+#' knitreg(list(model.1, model.2), center = FALSE, caption = "", table = FALSE)
+#'
+#' @export
+quartoreg <- function(...) {
+  if (!requireNamespace("knitr", quietly = TRUE)) {
+    stop("knitreg requires the 'knitr' package to be installed.\n",
+         "To do this, enter 'install.packages(\"knitr\")'.")
+  }
+  if(knitr::is_latex_output()) {
+    texreg(..., use.packages = FALSE) # do not print \usepackage{dcolumn} etc.
+  } else if(knitr::is_html_output()) {
+    htmlreg(..., doctype = FALSE, star.symbol = "&#42;") # the star symbol must be escaped in Markdown
+  } else if("docx" %in% knitr::opts_knit$get("rmarkdown.pandoc.to")) {
+    mr <- matrixreg(..., output.type = "ascii", include.attributes = FALSE, trim = TRUE)
+    colnames(mr) <- mr[1, ] # set column names because we want 'kable' to draw a horizontal  line under the model names
+    mr <- mr[-1, ] # remove the first row because we already set the model names as column names
+    knitr::kable(mr) # use the kable function to render the table in the Word document
+  } else { # whatever else knitr is throwing our way should prompt an ASCII table
+    screenreg(...)
+  }
+}
+
 
 #' Convert regression output to an ASCII table
 #'

--- a/R/texreg.R
+++ b/R/texreg.R
@@ -2656,7 +2656,13 @@ quartoreg <- function(...) {
     colnames(mr) <- mr[1, ] # set column names because we want 'kable' to draw a horizontal  line under the model names
     mr <- mr[-1, ] # remove the first row because we already set the model names as column names
     knitr::kable(mr) # use the kable function to render the table in the Word document
-  } else { # whatever else knitr is throwing our way should prompt an ASCII table
+  } else if("pptx" %in% knitr::opts_knit$get("rmarkdown.pandoc.to")) {
+    # FIXME: this only works when results=asis is turned **off**.
+    mr <- matrixreg(..., output.type = "ascii", include.attributes = FALSE, trim = TRUE)
+    colnames(mr) <- mr[1, ] # set column names because we want 'kable' to draw a horizontal  line under the model names
+    mr <- mr[-1, ] # remove the first row because we already set the model names as column names
+    knitr::kable(mr) # use the kable function to render the table in the Word document
+  } else {
     screenreg(...)
   }
 }

--- a/R/texreg.R
+++ b/R/texreg.R
@@ -697,6 +697,80 @@ knitreg <- function(...) {
   }
 }
 
+#' Flexibly choose the right table output format for use with \pkg{knitr}
+#'
+#' Flexibly choose the right table output format for use with \pkg{knitr}.
+#'
+#' This function automatically selects the right function (\link{texreg},
+#' \link{screenreg}, \link{htmlreg}, or \link{matrixreg}) with the right set of
+#' arguments for use with the \pkg{knitr} package, for example in RStudio. The
+#' advantage of using this function with \pkg{knitr} is that the user does not
+#' need to replace the \link{texreg}, \link{htmlreg} etc. function call in the
+#' document when a different output format is selected.
+#'
+#' \link{knitreg} works with...
+#' \itemize{
+#'   \item \R HTML documents (\code{.Rhtml} extension)
+#'   \item \R Sweave documents (\code{.Rnw} extension) for PDF output via LaTeX,
+#'     rendered using...
+#'     \itemize{
+#'       \item the \pkg{knitr} package
+#'       \item the \pkg{Sweave} package
+#'     }
+#'   \item \R Markdown documents (\code{.Rmd} extension), rendered as...
+#'     \itemize{
+#'       \item HTML documents
+#'       \item PDF documents
+#'       \item Word documents
+#'       \item Powerpoint presentations
+#'       \item Presentations (\code{.Rpres} extension, not \code{.Rmd})
+#'     }
+#'   \item \R Notebooks, including preview
+#' }
+#'
+#' If Markdown and HTML rendering are selected, \link{htmlreg} arguments
+#' \code{doctype = FALSE} and \code{star.symbol = "&#42;"} are set to enable
+#' compatibility with Markdown. With \R HTML documents (but not Markdown) or
+#' presentations (\code{.Rpres} extension), only \code{doctype = FALSE} is set.
+#'
+#' For PDF/LaTeX documents, the \link{texreg} argument
+#' \code{use.packages = FALSE} is set to suppress any package loading
+#' instructions in the preamble. The user must load any packages manually in the
+#' preamble of the document.
+#'
+#' The \pkg{knitr} and \pkg{rmarkdown} packages must be installed for this
+#' function to work.
+#'
+#' @param ... Arguments to be handed over to the \link{texreg}, \link{htmlreg},
+#'   \link{screenreg}, or \link{matrixreg} function. See the respective help
+#'   page for details.
+#' @return A table as a \code{character} string in the respective output format.
+#'
+#' @author Philip Leifeld, with input from David Hugh-Jones
+#' @family texreg
+#' @seealso \code{\link{texreg-package}} \code{\link{extract}}
+#'
+#' @examples
+#' require("nlme")
+#' model.1 <- lme(distance ~ age, data = Orthodont, random = ~ 1)
+#' model.2 <- lme(distance ~ age + Sex, data = Orthodont, random = ~ 1)
+#' knitreg(list(model.1, model.2), center = FALSE, caption = "", table = FALSE)
+#'
+#' @export
+quartoreg <- function(...) {
+  if (!requireNamespace("knitr", quietly = TRUE)) {
+    stop("knitreg requires the 'knitr' package to be installed.\n",
+         "To do this, enter 'install.packages(\"knitr\")'.")
+  }
+  if(knitr::is_latex_output()) {
+    texreg(..., use.packages = FALSE) # do not print \usepackage{dcolumn} etc.
+  } else if(knitr::is_html_output()) {
+    htmlreg(..., doctype = FALSE, star.symbol = "&#42;") # the star symbol must be escaped in Markdown
+  } else { # whatever else knitr is throwing our way should prompt an ASCII table
+    screenreg(...)
+  }
+}
+
 #' Convert regression output to a \code{character} matrix
 #'
 #' Conversion of \R regression output to a \code{character} matrix.


### PR DESCRIPTION
This is a very early draft PR to address issue #190. It adds a `quartoreg` function that should operate in the same manner as the `knitreg` function for [quarto](https://quarto.org) documents.

Right now, the function correctly identifies rendering for:

* HTML output, including revealjs presentations.
* LaTeX/PDF output, including beamer presentations.
* Word documents (using matrixreg). I have not successfully been able to get it to recognize powerpoint presentations yet.
* screenreg for interactive use.

Remaining issues are:

- [ ] Recognize pptx output
- [ ] Handle captioning properly through the `tbl-cap` code chunk option in quarto. Currently this works for pdf, but placement above or below does not respond to `tbl-cap-placement` option. HTML produces a caption but does not get a proper "Table X:" prefix. MS Word works properly.
- [ ] Other packages like gt are able to print processed code directly without the use of `results: asis`. It would be nice if quartoreg could do this as well.
- [ ] proper documentation.  Current documentation is just a copy-paste from knitreg.
- [ ] tests for `testthat`.