### PR TITLE
Skip for missing Suggests

### DIFF
--- a/tests/testthat/test-jss.R
+++ b/tests/testthat/test-jss.R
@@ -76,6 +76,8 @@ test_that("texreg returns output as in the JSS 2013 article", {
   # saveRDS(table, "../files/jss_texreg_gls.RDS")
 
   # How to use "robust" standard errors with texreg
+  skip_if_not_installed("sandwich")
+  skip_if_not_installed("lmtest")
   expect_equal({
       library("sandwich")
       library("lmtest")

--- a/tests/testthat/test-plotreg.R
+++ b/tests/testthat/test-plotreg.R
@@ -37,6 +37,7 @@ test_that("plotreg works", {
 test_that("plotreg works with confidence intervals using the biglm package", {
   skip_if_not_installed("ggplot2", minimum_version = "3.3.1")
   skip_if_not_installed("biglm")
+  skip_if_not_installed("broom")
   require("biglm")
   skip_if_not_installed("DBI")
   data("trees")


### PR DESCRIPTION
Particularly for test-plotreg, where the current error must be parsed carefully:

```
── Error (test-plotreg.R:47:3): plotreg works with confidence intervals using the biglm package ──
Error in `extract(l[[i]], ...)`: texreg does not directly support models of class bigglm, but it can sometimes use the ``broom`` package to extract model information. Call texreg again after installing the ``broom`` package to see if this is possible.
Backtrace:
    ▆
 1. └─texreg::plotreg(list(a, b)) at test-plotreg.R:47:3
 2.   └─texreg::get.data(l, ...)
 3.     ├─texreg::extract(l[[i]], ...)
 4.     └─texreg::extract(l[[i]], ...)
```