### PR TITLE
Update betareg extract function

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -1847,14 +1847,23 @@ extract.betareg <- function(model, include.precision = TRUE,
 
   s <- summary(model, ...)
 
-  coef.block <- s$coefficients$mu
+  extended <- identical(model$dist, "xbetax") || identical(model$dist, "xbeta")
+  if (extended) {
+    coef.block <- s$coefficients$mu
+  } else {
+    coef.block <- s$coefficients$mean
+  }
   if (include.precision == TRUE) {
-    phi <- s$coefficients$phi
+    if (extended) {
+      phi <- s$coefficients$phi
+    } else {
+      phi <- s$coefficients$precision
+    }
     rownames(phi) <- paste("Precision:", rownames(phi))
     coef.block <- rbind(coef.block, phi)
   }
-  if (include.nu == TRUE) {
-    nu <- s$coefficients$nu 
+  if (include.nu == TRUE && !is.null(s$coefficients$nu)) {
+    nu <- s$coefficients$nu
     rownames(nu) <- paste('Exceedence:', rownames(nu))
     coef.block <- rbind(coef.block, nu)
   }
@@ -1866,7 +1875,7 @@ extract.betareg <- function(model, include.precision = TRUE,
   gof <- numeric()
   gof.names <- character()
   gof.decimal <- logical()
-  if (include.pseudors == TRUE) {
+  if (include.pseudors == TRUE && is.numeric(model$pseudo.r.squared)) {
     pseudors <- model$pseudo.r.squared
     gof <- c(gof, pseudors)
     gof.names <- c(gof.names, "Pseudo R$^2$")

--- a/R/extract.R
+++ b/R/extract.R
@@ -1843,15 +1843,20 @@ setMethod("extract", signature = className("feis", "feisr"),
 #' @noRd
 extract.betareg <- function(model, include.precision = TRUE,
                             include.pseudors = TRUE, include.loglik = TRUE,
-                            include.nobs = TRUE, ...) {
+                            include.nobs = TRUE, include.nu = TRUE, ...) {
 
   s <- summary(model, ...)
 
-  coef.block <- s$coefficients$mean
+  coef.block <- s$coefficients$mu
   if (include.precision == TRUE) {
-    phi <- s$coefficients$precision
+    phi <- s$coefficients$phi
     rownames(phi) <- paste("Precision:", rownames(phi))
     coef.block <- rbind(coef.block, phi)
+  }
+  if (include.nu == TRUE) {
+    nu <- s$coefficients$nu 
+    rownames(nu) <- paste('Exceedence:', rownames(nu))
+    coef.block <- rbind(coef.block, nu)
   }
   names <- rownames(coef.block)
   co <- coef.block[, 1]
@@ -1898,10 +1903,11 @@ extract.betareg <- function(model, include.precision = TRUE,
 #' \code{\link[betareg]{betareg}} function in the \pkg{betareg} package.
 #'
 #' @param model A statistical model object.
-#' @param include.precision Report precision in the GOF block?
+#' @param include.precision Report precision in the coef block?
 #' @param include.pseudors Report pseudo R^2 in the GOF block?
 #' @param include.loglik Report the log likelihood in the GOF block?
 #' @param include.nobs Report the number of observations in the GOF block?
+#' @param include.nu Report the exceedence in the coef block? 
 #' @param ... Custom parameters, which are handed over to subroutines, in this
 #'   case to the \code{summary} method for the object.
 #'

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -1231,3 +1231,113 @@ test_that("extract logitr objects from the logitr package", {
   expect_length(tr@gof.decimal, 4)
   expect_equivalent(dim(matrixreg(mnl_pref)), c(15, 2))
 })
+
+# betareg (betareg) ----
+test_that("extract classic betareg objects from the betareg package", {
+  testthat::skip_on_cran()
+  skip_if_not_installed("betareg", minimum_version = "3.2.0")
+  require("betareg")
+  set.seed(12345)
+  n <- 200
+  x <- rnorm(n)
+  y <- plogis(1 + 0.5 * x + rnorm(n, sd = 0.5))
+  m <- betareg(y ~ x, data = data.frame(y = y, x = x))
+
+  tr <- extract(m)
+  expect_length(tr@coef.names, 3)
+  expect_length(tr@coef, 3)
+  expect_length(tr@se, 3)
+  expect_length(tr@pvalues, 3)
+  expect_length(tr@ci.low, 0)
+  expect_length(tr@ci.up, 0)
+  expect_length(tr@gof, 3)
+  expect_length(tr@gof.names, 3)
+  expect_length(tr@gof.decimal, 3)
+  expect_true("Pseudo R$^2$" %in% tr@gof.names)
+  expect_true("Precision: (phi)" %in% tr@coef.names)
+  expect_equivalent(dim(matrixreg(m)), c(10, 2))
+})
+
+test_that("extract extended-support betareg objects from the betareg package", {
+  testthat::skip_on_cran()
+  skip_if_not_installed("betareg", minimum_version = "3.2.0")
+  require("betareg")
+  set.seed(12345)
+  n <- 200
+  x <- rnorm(n)
+  y <- plogis(1 + 0.5 * x + rnorm(n, sd = 0.5))
+  y[1:5] <- 0
+  y[6:10] <- 1
+  m <- betareg(y ~ x, data = data.frame(y = y, x = x))
+
+  tr <- extract(m)
+  expect_length(tr@coef.names, 4)
+  expect_length(tr@coef, 4)
+  expect_length(tr@se, 4)
+  expect_length(tr@pvalues, 4)
+  expect_length(tr@ci.low, 0)
+  expect_length(tr@ci.up, 0)
+  expect_length(tr@gof, 2)
+  expect_length(tr@gof.names, 2)
+  expect_length(tr@gof.decimal, 2)
+  expect_false("Pseudo R$^2$" %in% tr@gof.names)
+  expect_true("Precision: (phi)" %in% tr@coef.names)
+  expect_true("Exceedence: Log(nu)" %in% tr@coef.names)
+  expect_equivalent(dim(matrixreg(m)), c(11, 2))
+})
+
+test_that("classic and extended betareg models combine in a table", {
+  testthat::skip_on_cran()
+  skip_if_not_installed("betareg", minimum_version = "3.2.0")
+  require("betareg")
+  set.seed(12345)
+  n <- 200
+  x <- rnorm(n)
+  y <- plogis(1 + 0.5 * x + rnorm(n, sd = 0.5))
+  y2 <- y
+  y2[1:5] <- 0
+  y2[6:10] <- 1
+  m1 <- betareg(y ~ x, data = data.frame(y = y, x = x))
+  m2 <- betareg(y2 ~ x, data = data.frame(y2 = y2, x = x))
+
+  m <- matrixreg(list(m1, m2))
+  expect_equivalent(dim(m), c(12, 3))
+  expect_true("Exceedence: Log(nu)" %in% m[, 1])
+  expect_true("Pseudo R^2" %in% m[, 1])
+})
+
+test_that("betareg extract include flags work correctly", {
+  testthat::skip_on_cran()
+  skip_if_not_installed("betareg", minimum_version = "3.2.0")
+  require("betareg")
+  set.seed(12345)
+  n <- 200
+  x <- rnorm(n)
+  y <- plogis(1 + 0.5 * x + rnorm(n, sd = 0.5))
+  y2 <- y
+  y2[1:5] <- 0
+  y2[6:10] <- 1
+  m1 <- betareg(y ~ x, data = data.frame(y = y, x = x))
+  m2 <- betareg(y2 ~ x, data = data.frame(y2 = y2, x = x))
+
+  # classic model without precision
+  tr <- extract(m1, include.precision = FALSE)
+  expect_length(tr@coef.names, 2)
+  expect_false("Precision: (phi)" %in% tr@coef.names)
+
+  # classic model without pseudo R^2
+  tr <- extract(m1, include.pseudors = FALSE)
+  expect_length(tr@gof, 2)
+  expect_false("Pseudo R$^2$" %in% tr@gof.names)
+
+  # extended model without nu
+  tr <- extract(m2, include.nu = FALSE)
+  expect_length(tr@coef.names, 3)
+  expect_false("Exceedence: Log(nu)" %in% tr@coef.names)
+
+  # extended model without precision
+  tr <- extract(m2, include.precision = FALSE)
+  expect_length(tr@coef.names, 3)
+  expect_false("Precision: (phi)" %in% tr@coef.names)
+  expect_true("Exceedence: Log(nu)" %in% tr@coef.names)
+})


### PR DESCRIPTION
Hi, 
i've been having issues making texreg tables with `betareg::betareg` since the library [introduced expanded support](https://github.com/cran/betareg/blob/master/NEWS.md) for target variables with values [0, 1]. The new model silently changes the betareg data structure based on your target's values. 

this pr just makes the `extract.betareg` method context-aware for when the model is using open vs closed intervals in the target. 

i've also added a few tests that mimic other models' style since `extract.betareg` didn't have any. 